### PR TITLE
Add new aws_cost_collector module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /team-cost-reporter/config.yaml
 *.pyc
 .DS_Store
+.idea/

--- a/sample-config/config.yaml
+++ b/sample-config/config.yaml
@@ -23,7 +23,7 @@ plugins:
 
   - name: "s3"
     friendly_name: "S3 Storage"
-    data_url: "https://api.cloudcheckr.com/api/billing.json/get_detailed_billing_with_grouping?access_key=BLAH&saved_filter_name=s3costsbyemail"
+    aws_ce: "acme:email"
 
   - name: "eb"
     friendly_name: "Elastic Beanstalk"

--- a/team-cost-reporter/aws_cost_collector.py
+++ b/team-cost-reporter/aws_cost_collector.py
@@ -1,0 +1,79 @@
+import logging
+import datetime
+import boto3
+
+logging.getLogger('botocore').setLevel(logging.CRITICAL)
+
+
+def id():
+    return "aws_cost_collector"
+
+
+def log (message):
+    print id() + ": " + message
+
+
+def get_start_end_strings(number_of_days):
+    ''' get the start and end date strings based on the number of days to report '''
+    now = datetime.datetime.now()
+    n_days_ago = now - datetime.timedelta(days=number_of_days)
+
+    current_date_str = now.strftime("%Y-%m-%d")
+    n_days_ago_str = n_days_ago.strftime("%Y-%m-%d")
+
+    # start=2016-06-01
+    # end=2016-06-30
+    start_string = n_days_ago_str
+    end_string = current_date_str
+    return (start_string,end_string)
+
+
+def _get_costs(ce_client, days_to_report, granularity, filter, group_by, next_token=None, debug=False):
+    result = []
+    start_date, end_date = get_start_end_strings(days_to_report)
+    time_period = {'Start': start_date, 'End': end_date}
+    metrics = ['UnblendedCost', 'BlendedCost', 'UsageQuantity']
+    if next_token:
+        query_result = ce_client.get_cost_and_usage(TimePeriod=time_period,
+                                                    Granularity=granularity,
+                                                    Filter=filter,
+                                                    Metrics=metrics,
+                                                    GroupBy=group_by,
+                                                    NextPageToken=next_token)
+    else:
+        query_result = ce_client.get_cost_and_usage(TimePeriod=time_period,
+                                                    Granularity=granularity,
+                                                    Filter=filter,
+                                                    Metrics=metrics,
+                                                    GroupBy=group_by)
+
+    if 'ResultsByTime' in query_result:
+        if 'NextPageToken' in query_result:
+            if debug:
+                log(query_result['ResultsByTime'])
+                log("More results to come...")
+            result.extend(query_result['ResultsByTime'])
+            result.extend(_get_costs(ce_client=ce_client,
+                                     days_to_report=days_to_report,
+                                     granularity=granularity,
+                                     filter=filter,
+                                     group_by=group_by,
+                                     next_token=query_result['NextPageToken'],
+                                     debug=debug))
+        else:
+            if debug: log(query_result['ResultsByTime'])
+            result.extend(query_result['ResultsByTime'])
+
+    return result
+
+
+def get_costs(days_to_report, granularity, filter, group_by, debug=False):
+    SESSION = boto3.session.Session()
+    CE = SESSION.client('ce')
+    return _get_costs(ce_client=CE,
+                      days_to_report=days_to_report,
+                      granularity=granularity,
+                      filter=filter,
+                      group_by=group_by,
+                      next_token=None,
+                      debug=debug)

--- a/team-cost-reporter/cloudcheckr.py
+++ b/team-cost-reporter/cloudcheckr.py
@@ -1,15 +1,20 @@
-import urllib2,json
+import urllib2
+import json
+import logging
 from jsonmerge import Merger
 import datetime
+
 
 def id():
     return "cloudcheckr"
 
+
 def log (message):
     print id() + ": " + message
 
-# get the start and end filter string based on the number of days to report
+
 def getStartEndFilterString(number_of_days):
+    ''' get the start and end filter string based on the number of days to report '''
     now = datetime.datetime.now()
     n_days_ago = now - datetime.timedelta(days=number_of_days)
 
@@ -20,6 +25,7 @@ def getStartEndFilterString(number_of_days):
     start_end_string = "start=" + n_days_ago_str + "&end=" + current_date_str
 
     return start_end_string
+
 
 def loadData(base_url,days_to_report,merge_field = "Groupings",debug=False):
     moreData = True
@@ -61,3 +67,106 @@ def loadData(base_url,days_to_report,merge_field = "Groupings",debug=False):
             moreData = False
 
     return data_full
+
+
+def convert(cost_data, tag, debug=False):
+    return_data = {}
+    totals = {}
+    total = 0
+    count = 0
+    min = 0
+    max = 0
+
+    # Grouping by tag results in a key with the tag name plus a $
+    tag_split = tag + '$'
+
+    # Temporary dict used for storing groupings based on tag
+    tag_dict = {}
+
+    # Each element in the cost_data list is for a particular day
+    for time_period in cost_data:
+        date_entry = time_period['TimePeriod']['Start'] + 'T00:00:00'
+        for group in time_period['Groups']:
+            key = group['Keys'][0]
+            if debug: log('Key: %s' % key)
+            if not key.split(tag_split)[1]:
+                tag_value = tag + ' untagged'
+            else:
+                tag_value = tag + ' ' + key.split(tag_split)[1]
+            amount = float(group['Metrics']['BlendedCost']['Amount'])
+            if count == 0:
+                # Set an initial min amount
+                min = amount
+            total += amount
+            count += 1
+            if amount > max:
+                max = amount
+            if amount < min:
+                min = amount
+            cost_entry = {"Date": date_entry, "Amount": amount, "UsageQuantity": 0.0}
+            if tag_value in tag_dict:
+                # Already have a dict entry for this tag_value - append another item to the list
+                tag_dict[tag_value].append(cost_entry)
+            else:
+                # No entry for this tag_value - start a new list
+                tag_dict[tag_value] = [cost_entry]
+
+    # At this point, tag_dict is a dict with keys for each unique tag_value
+    # eg.
+    # {
+    #     "acme:email user1@domain" : [
+    #         {
+    #            "Date": "2018-01-01T00:00:00",
+    #            "Amount": float,
+    #            "UsageQuantity": 0.0
+    #         },
+    #         {
+    #            "Date": "2018-01-02T00:00:00",
+    #            "Amount": float,
+    #            "UsageQuantity": 0.0
+    #         }
+    #     ],
+    #     "acme:email user2@domain" : [
+    #         {
+    #            "Date": "2018-01-01T00:00:00",
+    #            "Amount": float,
+    #            "UsageQuantity": 0.0
+    #         },
+    #         {
+    #            "Date": "2018-01-02T00:00:00",
+    #            "Amount": float,
+    #            "UsageQuantity": 0.0
+    #         }
+    #     ]
+    # }
+    # Need the following format:
+    # Format:
+    # {
+    #    "Total": float, "Max": float, "Min": float, "Average": float,
+    #    "Groupings": [
+    #       {
+    #          "Name": "acme:email user1@domain.com",
+    #          "Costs": [
+    #             {
+    #                "Date": "2018-01-01T00:00:00",
+    #                "Amount": float,
+    #                "UsageQuantity": 0.0
+    #             },...
+    #          ]
+    #       },...
+    #   ]
+    # }
+
+    groupings = []
+    for unique_tag in tag_dict:
+        group_entry = {}
+        group_entry['Name'] = unique_tag
+        group_entry['Costs'] = tag_dict[unique_tag]
+        groupings.append(group_entry)
+
+    return_data['Total'] = total
+    return_data['Max'] = max
+    return_data['Min'] = min
+    return_data['Average'] = total / count
+    return_data['Groupings'] = groupings
+    return return_data

--- a/team-cost-reporter/plugins/s3/__init__.py
+++ b/team-cost-reporter/plugins/s3/__init__.py
@@ -1,14 +1,15 @@
-import urllib2,json,imp
-import pprint
-
 # Project modules
 import cloudcheckr
+import aws_cost_collector
+
 
 def id():
     return "s3"
 
+
 def log (message):
     print id() + ": " + message
+
 
 def getTeamCost(team_name,configMap,debug):
     team_cost = dict(individual=dict())
@@ -20,40 +21,71 @@ def getTeamCost(team_name,configMap,debug):
     log("getting team cost for team: %s for %i days" % (team_name,days_to_report))
 
     # get the data url for the plugin
+    data = None
+    data_url = None
+    aws_ce = False
     for config_plugin in configMap['plugins']:
         if config_plugin['name'] == id():
             if debug: log("plugin info found in config file")
-            data_url = config_plugin['data_url']
+            if 'data_url' in config_plugin:
+                data_url = config_plugin['data_url']
+                log("   getting data from cloudcheckr")
+                # get the report data from cloudcheckr which is by tag
+                data = cloudcheckr.loadData(data_url, days_to_report, "Groupings", debug)
+            elif 'aws_ce' in config_plugin:
+                group_by_tag = config_plugin['aws_ce']
+                granularity = 'DAILY'
+                filter = {
+                    "Dimensions": {
+                        "Key": "SERVICE",
+                        "Values": [
+                            "Amazon Simple Storage Service"
+                        ]
+                    }
+                }
+                metrics = ['UnblendedCost', 'BlendedCost', 'UsageQuantity']
+                group_by = [
+                    {
+                        "Type": "TAG",
+                        "Key": group_by_tag
+                    }
+                ]
+                # get the report data from aws cost explorer
+                log("   getting data from aws using cost explorer")
+                data = aws_cost_collector.get_costs(days_to_report=days_to_report,
+                                                    granularity=granularity,
+                                                    filter=filter,
+                                                    group_by=group_by,
+                                                    debug=debug)
+                # We need to convert this to cloudcheckr format
+                data = cloudcheckr.convert(data, group_by_tag, debug)
 
-    if data_url:
-        # get the report data from cloudcheckr which is by tag
-        data = cloudcheckr.loadData(data_url,days_to_report,"Groupings",debug)
-        if data:
-            if debug: log("%i tags returned" % len(data['Groupings']))
+    if data:
+        if debug: log("%i tags returned" % len(data['Groupings']))
 
-            # Find our team info in the config file
-            for team in configMap['teams']:
-                if team['name'] == team_name:
-                    team_members = team['members']
-                    tag_to_match = team[id()]['include_tag']
+        # Find our team info in the config file
+        for team in configMap['teams']:
+            if team['name'] == team_name:
+                team_members = team['members']
+                tag_to_match = team[id()]['include_tag']
 
-            if debug: log("Looking in cloudcheckr report data for tag name %s" % tag_to_match)
+        if debug: log("Looking in report data for tag name %s" % tag_to_match)
 
-            # look in the data from cloudcheckr for a tag value matching that we are looking for
-            for tag in data['Groupings']:
-                # Assume the memberID/email in the config file is lower case
-                member_id = str(tag['Name'].split(tag_to_match)[1]).strip().lower()
-                if debug: log("member_id in cloudcheckr data is %s" % member_id)
-                if member_id in team_members:
-                    if debug: log("team member found in cloudcheckr data: %s" % member_id)
+        # look in the data from cloudcheckr for a tag value matching that we are looking for
+        for tag in data['Groupings']:
+            # Assume the memberID/email in the config file is lower case
+            member_id = str(tag['Name'].split(tag_to_match)[1]).strip().lower()
+            if debug: log("member_id in report data is %s" % member_id)
+            if member_id in team_members:
+                if debug: log("team member found in report data: %s" % member_id)
 
-                    # Now we can get their cost from the cloudcheckr data
-                    totalCost = 0
-                    for costitem in tag['Costs']:
-                        totalCost = totalCost + costitem['Amount']
+                # Now we can get their cost from the cloudcheckr data
+                totalCost = 0
+                for costitem in tag['Costs']:
+                    totalCost = totalCost + costitem['Amount']
 
-                    if debug: log("total cost for %s is %s" % (member_id,totalCost))
+                if debug: log("total cost for %s is %s" % (member_id,totalCost))
 
-                    team_cost['individual'][member_id] = format(float(totalCost),'.2f')
+                team_cost['individual'][member_id] = format(float(totalCost),'.2f')
 
     return team_cost

--- a/team-cost-reporter/requirements.txt
+++ b/team-cost-reporter/requirements.txt
@@ -1,2 +1,3 @@
 pyyaml
 jsonmerge
+boto3

--- a/team-cost-reporter/team-cost-reporter.py
+++ b/team-cost-reporter/team-cost-reporter.py
@@ -1,11 +1,10 @@
-import imp,argparse
+import argparse
 import os,sys
-import json,yaml
-import pprint
-
+import yaml
 # Project modules
 import plugin
 import output
+
 
 def readConfigFile(path):
     configMap = []
@@ -19,7 +18,7 @@ def readConfigFile(path):
 
     return configMap
 
-## mainFile
+
 def main(argv):
     plugin_results = dict()
 


### PR DESCRIPTION
Add new aws_cost_collector module for getting data from the AWS Cost Explorer, instead of from cloudcheckr

I've sort of written each file (s3.py, etc) as a standalone unit that can be called, but they are also imported into aws_cost_collector and used from there. Can easily remove the main method if you don't like that/think it has any benefit.