### PR TITLE
DynamoDB can now use AWS CostExplorer

### DIFF
--- a/sample-config/config.yaml
+++ b/sample-config/config.yaml
@@ -84,22 +84,36 @@ plugins:
   - name : "dynamodb"
     friendly_name: "DynamoDB"
     # data_url: "https://api.cloudcheckr.com/api/inventory.json/get_resources_dynamodb_details?access_key=BLAH"
-    aws_dynamodb:
-      accounts:
-        - name: "Account 1"
-          credentials:
-            role_arn: "arn:aws:iam::234567890123:role/ATCR_Role"
-            external_id: "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-          regions:
-            - "us-east-1"
-            - "us-west-2"
-        - name: "Account 2"
-          credentials:
-            role_arn: "arn:aws:iam::345678901234:role/ATCR_Role"
-            external_id: "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-          regions:
-            - "us-west-1"
-            - "eu-west-1"
+    #aws_dynamodb:
+    #  accounts:
+    #    - name: "Account 1"
+    #      credentials:
+    #        role_arn: "arn:aws:iam::234567890123:role/ATCR_Role"
+    #        external_id: "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    #      regions:
+    #        - "us-east-1"
+    #        - "us-west-2"
+    #    - name: "Account 2"
+    #      credentials:
+    #        role_arn: "arn:aws:iam::345678901234:role/ATCR_Role"
+    #        external_id: "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    #      regions:
+    #        - "us-west-1"
+    #        - "eu-west-1"
+    aws_ce:
+      group_by_tag: "table-name"
+      filter:
+        And:
+          - Not:
+              Dimensions:
+                Key: "LINKED_ACCOUNT"
+                Values:
+                  - "123456789012"
+          - Dimensions:
+              Key: SERVICE
+              Values:
+                - "Amazon DynamoDB"
+
 
 teams:
   - name: "one"
@@ -125,6 +139,7 @@ teams:
         - "ECS-Cluster_one"
         - "ECS-Cluster-two"
     dynamodb:
+      include_tag: "table-name"
       tables:
         - "teamone*"
         - "AutomatedTestReports"

--- a/team-cost-reporter/plugins/dynamodb/__init__.py
+++ b/team-cost-reporter/plugins/dynamodb/__init__.py
@@ -1,7 +1,9 @@
 import logging
 import boto3
 # Project modules
+import aws_cost_collector
 import cloudcheckr
+
 
 logging.getLogger('botocore').setLevel(logging.CRITICAL)
 
@@ -93,7 +95,7 @@ def get_table_info(account_list, debug=False):
 
 def getDailyTableCost(prov_read,prov_write,storage):
     '''
-    We need this here because the data from cloudcheckR is incorrect
+    We need this here because the data from cloudcheckr is incorrect
     When cloudcheckr is fixed, this is no longer needed
     :param prov_read: provisioned read throughput
     :param prov_write: provisioned write throughput
@@ -142,8 +144,33 @@ def getTeamCost(team_name,configMap,debug):
                 # over the time period for something like autoscaling of throughput or changes in table size
                 # Same limitation applies equally to the cloudcheckr data, so we're no worse off...
                 data = get_table_info(account_list, debug)
+            elif 'aws_ce' in config_plugin:
+                group_by_tag = None
+                if 'group_by_tag' in config_plugin['aws_ce']:
+                    group_by_tag = config_plugin['aws_ce']['group_by_tag']
+                group_by = None
+                if group_by_tag:
+                    group_by = [
+                        {
+                            "Type": "TAG",
+                            "Key": group_by_tag
+                        }
+                    ]
+                granularity = 'DAILY'
+                if 'filter' in config_plugin['aws_ce']:
+                    filter = config_plugin['aws_ce']['filter']
+                if group_by_tag and filter:
+                    # get the report data from aws cost explorer
+                    log("   getting data from aws using cost explorer")
+                    data = aws_cost_collector.get_costs(days_to_report=days_to_report,
+                                                        granularity=granularity,
+                                                        filter=filter,
+                                                        group_by=group_by,
+                                                        debug=debug)
+                    # We need to convert this to cloudcheckr format
+                    data = cloudcheckr.convert(data, group_by_tag, debug)
 
-    if data:
+    if data and 'aws_dynamodb' in config_plugin:
         if debug: log("%i tables returned" % len(data['DynamoDbDetails']))
 
         # Find our team info in the config file
@@ -196,6 +223,68 @@ def getTeamCost(team_name,configMap,debug):
                     if debug: log("total cost for %s is %s" % (cc_table_name,totalCost))
 
                     team_cost['shared'][cc_table_name] = format(float(totalCost),'.2f')
+                    totalCost = 0
+
+    elif data and 'aws_ce' in config_plugin:
+        tag_to_match = None
+        if debug: log("%i tags returned" % len(data['Groupings']))
+
+        # Find our team info in the config file
+        for team in configMap['teams']:
+            if team['name'] == team_name:
+                tag_to_match = team[id()]['include_tag']
+                config_envs = team[id()]['tables']
+
+        for config_match_env in config_envs:
+            log("looking for dynamodb owner %s in report data" % config_match_env)
+
+            for cc_env in data['Groupings']:
+                tag_value = cc_env['Name'].split(tag_to_match)
+                if debug: log("tag_value: " + str(tag_value))
+
+                if len(tag_value) == 2:
+                    cc_env_name = str(tag_value[1].strip().lower())
+                else:
+                    continue
+
+                if debug: log("dynamodb table in report data is %s" % cc_env_name)
+
+                # See if we're dealing with a wildcard or exact match
+                match = False
+                if str(config_match_env).startswith("*") and str(config_match_env).endswith("*"):
+                    contain_match = config_match_env.split("*")[1]
+                    if debug: log("wildcard matching- contains %s" % contain_match)
+
+                    if contain_match.lower() in cc_env_name.lower():
+                        if debug: log("Contains match found")
+                        match = True
+                elif str(config_match_env).endswith("*"):
+                    prefix = config_match_env.split("*")[0]
+                    if debug: log("wildcard matching - prefix %s" % prefix)
+
+                    if cc_env_name.lower().startswith(prefix.lower()):
+                        if debug: log("Wildcard prefix match found")
+                        match = True
+                elif str(config_match_env).startswith("*"):
+                    suffix = config_match_env.split("*")[1]
+                    if debug: log("wildcard matching - suffix %s" % suffix)
+
+                    if cc_env_name.lower().endswith(suffix.lower()):
+                        if debug: log("Wildcard suffix match found")
+                        match = True
+                elif config_match_env.lower() == cc_env_name.lower():
+                    if debug: log("Exact matching")
+                    match = True
+
+                if match:
+                    # Match found - add cost
+                    if debug: log("*** Matching ecs cluster  found")
+                    for costitem in cc_env['Costs']:
+                        totalCost = totalCost + costitem['Amount']
+
+                        if debug: log("total cost for %s is %s" % (cc_env_name, totalCost))
+
+                    team_cost['shared'][cc_env_name] = format(float(totalCost), '.2f')
                     totalCost = 0
 
     return team_cost

--- a/team-cost-reporter/plugins/dynamodb/__init__.py
+++ b/team-cost-reporter/plugins/dynamodb/__init__.py
@@ -84,31 +84,31 @@ def _get_table_info(account_creds, region_list, debug=False):
     return account_dynamo_details
 
 
-def _is_match(cc_env_name, config_match_env, debug=False):
+def _is_match(from_results, from_config_file, debug=False):
     # See if we're dealing with a wildcard or exact match
     match = False
-    if str(config_match_env).startswith("*") and str(config_match_env).endswith("*"):
-        contain_match = config_match_env.split("*")[1]
+    if str(from_config_file).startswith("*") and str(from_config_file).endswith("*"):
+        contain_match = from_config_file.split("*")[1]
         if debug: log("wildcard matching- contains %s" % contain_match)
 
-        if contain_match.lower() in cc_env_name.lower():
+        if contain_match.lower() in from_results.lower():
             if debug: log("Contains match found")
             match = True
-    elif str(config_match_env).endswith("*"):
-        prefix = config_match_env.split("*")[0]
+    elif str(from_config_file).endswith("*"):
+        prefix = from_config_file.split("*")[0]
         if debug: log("wildcard matching - prefix %s" % prefix)
 
-        if cc_env_name.lower().startswith(prefix.lower()):
+        if from_results.lower().startswith(prefix.lower()):
             if debug: log("Wildcard prefix match found")
             match = True
-    elif str(config_match_env).startswith("*"):
-        suffix = config_match_env.split("*")[1]
+    elif str(from_config_file).startswith("*"):
+        suffix = from_config_file.split("*")[1]
         if debug: log("wildcard matching - suffix %s" % suffix)
 
-        if cc_env_name.lower().endswith(suffix.lower()):
+        if from_results.lower().endswith(suffix.lower()):
             if debug: log("Wildcard suffix match found")
             match = True
-    elif config_match_env.lower() == cc_env_name.lower():
+    elif from_config_file.lower() == from_results.lower():
         if debug: log("Exact matching")
         match = True
     return match


### PR DESCRIPTION
Added the ability to use AWS CostExplorer with DynamoDB. This uses the same format as the other plugins, and filters on the tag table-name.